### PR TITLE
ci(actions): add a block-direct-commits worksflow

### DIFF
--- a/.github/workflows/block-direct-commits.yml
+++ b/.github/workflows/block-direct-commits.yml
@@ -1,0 +1,18 @@
+name: Block Direct Commits
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  prevent-direct-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for direct commits
+        run: |
+          AUTHOR=$(git log -1 --pretty=format:'%an')
+          if [[ "$AUTHOR" != "GitHub" ]]; then
+            echo "❌ Direct commits to master are not allowed. Please use a pull request."
+            exit 1
+          fi


### PR DESCRIPTION
GitHub actions are set up to avoid commits directly to the master branch.